### PR TITLE
Improve workshop documentation

### DIFF
--- a/01.baby-steps/01.frontend/readme.md
+++ b/01.baby-steps/01.frontend/readme.md
@@ -1,2 +1,5 @@
-node version : at least 16
-run on /opt/ at wsl
+This folder contains the consumer example written in Node.js.
+
+- Requires Node.js 16 or newer.
+- Run `npm install` once to install dependencies.
+- Execute `npm test` to run the consumer Pact tests.

--- a/01.baby-steps/02.backend/readme.md
+++ b/01.baby-steps/02.backend/readme.md
@@ -1,14 +1,5 @@
-use java 17
-sudo apt install openjdk-17-jre-headless
+This folder contains the provider example built with Spring Boot.
 
-use gradle
-
-sudo apt  install gradle
-sudo apt remove gradle
-wget https://services.gradle.org/distributions/gradle-7.5-bin.zip
-sudo unzip -d /opt/gradle gradle-7.5-bin.zip
-nano ~/.bashrc
-ctrol + end > ctrl + v
-export PATH=$PATH:/opt/gradle/gradle-7.5/bin
-
-source ~/.bashrc
+- Requires Java 17 and Gradle.
+- Start the application with `./gradlew bootRun`.
+- Run provider verification tests with `./gradlew test`.

--- a/01.baby-steps/pact-broker/README.md
+++ b/01.baby-steps/pact-broker/README.md
@@ -1,0 +1,3 @@
+Local Pact Broker used by the examples.
+
+Run `docker compose up -d` in this directory to start the broker.

--- a/01.baby-steps/readme.md
+++ b/01.baby-steps/readme.md
@@ -1,1 +1,24 @@
-Initialize a local docker environment to run
+# Step 1: Baby Steps
+
+This example introduces a simple consumer and provider using Pact.
+
+## Setup
+
+1. **Start the Pact Broker**
+   ```bash
+   cd pact-broker
+   docker compose up -d
+   ```
+2. **Run the provider**
+   ```bash
+   cd 02.backend
+   ./gradlew bootRun
+   ```
+3. **Run the consumer tests**
+   ```bash
+   cd 01.frontend
+   npm install
+   npm test
+   ```
+
+Pact files are created in the `pacts` directory and can be published to the broker using the helper in the tests.

--- a/02.The Intro Strikes Back/readme.md
+++ b/02.The Intro Strikes Back/readme.md
@@ -1,0 +1,3 @@
+# Step 2: The Intro Strikes Back
+
+Additional exercises exploring more Pact features will be added here.

--- a/03. Return of the Test-i/readme.md
+++ b/03. Return of the Test-i/readme.md
@@ -1,0 +1,3 @@
+# Step 3: Return of the Test-i
+
+This step will cover provider verification against published contracts.

--- a/04.The Prophecy Fulfilled - Code Harmony/readme.md
+++ b/04.The Prophecy Fulfilled - Code Harmony/readme.md
@@ -1,0 +1,3 @@
+# Step 4: The Prophecy Fulfilled - Code Harmony
+
+The final step demonstrates a complete consumer and provider workflow.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Contract Testing Workshop
+
+This repository contains a series of examples that demonstrate how to apply contract testing using [Pact](https://docs.pact.io/).
+Each folder represents a step in the learning journey.
+
+## Steps
+
+1. **01.baby-steps** – Minimal consumer and provider projects with a local Pact Broker.
+2. **02.The Intro Strikes Back** – Extends the basic example with more features.
+3. **03. Return of the Test-i** – Shows how provider verification works.
+4. **04.The Prophecy Fulfilled - Code Harmony** – Final scenario with the full workflow.
+
+Open the `README.md` inside each step for instructions.
+
+## Requirements
+
+- [Docker](https://docs.docker.com/get-docker/) to run the Pact Broker.
+- [Node.js](https://nodejs.org/) 16 or newer for the frontend consumer.
+- [Java](https://adoptium.net/) 17 and [Gradle](https://gradle.org/) for the backend provider.
+
+To get started, begin with the **01.baby-steps** folder.


### PR DESCRIPTION
## Summary
- add root README with project overview
- document setup for step 1
- add notes for frontend, backend and broker folders
- provide placeholder docs for remaining steps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6849f5670084832f9c1224bb5c175dec